### PR TITLE
Change document title on doc index page

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -1,10 +1,5 @@
-o({})
-=====
-
---------------
-
 Atom
-----
+====
 
 Atom is a simple and powerful OO application toolkit for Javascript.
 


### PR DESCRIPTION
This title is used in the TOC and Sphinx apparently has a problem including this as a subtree element.